### PR TITLE
feat: 支持腾讯问卷 star 与 matrix_star 题型

### DIFF
--- a/tencent/provider/parser.py
+++ b/tencent/provider/parser.py
@@ -20,6 +20,7 @@ QQ_SUPPORTED_PROVIDER_TYPES = {
     "text",
     "textarea",
     "nps",
+    "star",
     "matrix_radio",
     "matrix_star",
 }
@@ -30,6 +31,7 @@ QQ_PROVIDER_TYPE_TO_INTERNAL = {
     "text": "1",
     "textarea": "1",
     "nps": "5",
+    "star": "5",
     "matrix_radio": "6",
     "matrix_star": "6",
 }
@@ -248,7 +250,7 @@ def _fetch_qq_survey_via_http(survey_id: str, hash_value: str) -> Tuple[List[Dic
 
 
 def _build_option_texts(question: Dict[str, Any], provider_type: str) -> List[str]:
-    if provider_type == "nps":
+    if provider_type in {"nps", "star"}:
         start = int(question.get("star_begin_num") or 0)
         count = max(0, int(question.get("star_num") or 0))
         return [str(start + idx) for idx in range(count)]
@@ -316,7 +318,7 @@ def _build_row_texts(question: Dict[str, Any]) -> List[str]:
 
 
 def _resolve_option_count(question: Dict[str, Any], provider_type: str, option_texts: List[str]) -> int:
-    if provider_type == "nps":
+    if provider_type in {"nps", "star"}:
         return max(len(option_texts), int(question.get("star_num") or 0))
     if provider_type == "matrix_star":
         return max(len(option_texts), int(question.get("star_num") or 0))
@@ -360,7 +362,7 @@ def _standardize_qq_questions(questions: List[Dict[str, Any]]) -> List[Dict[str,
         supported = provider_type in QQ_SUPPORTED_PROVIDER_TYPES
         unsupported_reason = "" if supported else f"暂不支持腾讯题型：{provider_type or 'unknown'}"
         is_text_like = provider_type in {"text", "textarea"}
-        is_rating = provider_type == "nps"
+        is_rating = provider_type in {"nps", "star"}
         multi_min_limit = question.get("min_length") if provider_type == "checkbox" else None
         multi_max_limit = question.get("max_length") if provider_type == "checkbox" else None
         normalized.append({

--- a/tencent/provider/runtime.py
+++ b/tencent/provider/runtime.py
@@ -20,6 +20,7 @@ from tencent.provider.submission import submit
 from .runtime_answerers import (
     _answer_qq_dropdown,
     _answer_qq_matrix,
+    _answer_qq_matrix_star,
     _answer_qq_multiple,
     _answer_qq_score_like,
     _answer_qq_single,
@@ -118,7 +119,10 @@ def brush_qq(
             elif entry_type in {"scale", "score"}:
                 _answer_qq_score_like(driver, question, config_index, ctx, psycho_plan=psycho_plan)
             elif entry_type == "matrix":
-                _answer_qq_matrix(driver, question, config_index, ctx, psycho_plan=psycho_plan)
+                if question.get("provider_type") == "matrix_star":
+                    _answer_qq_matrix_star(driver, question, config_index, ctx, psycho_plan=psycho_plan)
+                else:
+                    _answer_qq_matrix(driver, question, config_index, ctx, psycho_plan=psycho_plan)
             else:
                 logging.warning("腾讯问卷第%d题暂未接入运行时类型：%s", question_num, entry_type)
 

--- a/tencent/provider/runtime_answerers.py
+++ b/tencent/provider/runtime_answerers.py
@@ -517,3 +517,86 @@ def _answer_qq_multiple(
     if confirmed:
         selected_texts = [option_texts[i] for i in confirmed if i < len(option_texts)]
         record_answer(current, "multiple", selected_indices=confirmed, selected_texts=selected_texts)
+
+
+def _answer_qq_matrix_star(
+    driver: BrowserDriver,
+    question: Dict[str, Any],
+    config_index: int,
+    ctx: TaskContext,
+    *,
+    psycho_plan: Optional[Any],
+) -> int:
+    """处理腾讯问卷矩阵星级题（matrix_star）。
+
+    逻辑与普通矩阵题相同，但用 _click_star_cell 代替 _click_matrix_cell，
+    因为星级组件基于 TDesign t-rate，不含 input[type="radio"]。
+    """
+    current = int(question.get("num") or 0)
+    question_id = str(question.get("provider_question_id") or "")
+    row_count = max(1, int(question.get("rows") or 1))
+    option_count = max(2, int(question.get("options") or 0))
+    option_texts = list(question.get("option_texts") or [])
+    strict_ratio_question = is_strict_ratio_question(ctx, current)
+    next_index = config_index
+    for row_index in range(row_count):
+        raw_probabilities = ctx.matrix_prob[next_index] if next_index < len(ctx.matrix_prob) else -1
+        next_index += 1
+        strict_reference: Optional[List[float]] = None
+        row_probabilities: Any = -1
+        if isinstance(raw_probabilities, list):
+            try:
+                probs = [float(value) for value in raw_probabilities]
+            except Exception:
+                probs = []
+            if len(probs) != option_count:
+                probs = [1.0] * option_count
+            strict_reference = list(probs)
+            probs = apply_matrix_row_consistency(probs, current, row_index)
+            if any(prob > 0 for prob in probs):
+                row_probabilities = resolve_distribution_probabilities(
+                    probs,
+                    option_count,
+                    ctx,
+                    current,
+                    row_index=row_index,
+                    psycho_plan=psycho_plan,
+                    priority_mode=getattr(ctx, "reliability_priority_mode", None),
+                )
+        else:
+            uniform_probs = apply_matrix_row_consistency([1.0] * option_count, current, row_index)
+            if any(prob > 0 for prob in uniform_probs):
+                row_probabilities = resolve_distribution_probabilities(
+                    uniform_probs,
+                    option_count,
+                    ctx,
+                    current,
+                    row_index=row_index,
+                    psycho_plan=psycho_plan,
+                    priority_mode=getattr(ctx, "reliability_priority_mode", None),
+                )
+        if strict_ratio_question and isinstance(row_probabilities, list):
+            row_probabilities = enforce_reference_rank_order(row_probabilities, strict_reference or row_probabilities)
+        selected_index = get_tendency_index(
+            option_count,
+            row_probabilities,
+            dimension=ctx.question_dimension_map.get(current),
+            psycho_plan=psycho_plan,
+            question_index=current,
+            row_index=row_index,
+            priority_mode=getattr(ctx, "reliability_priority_mode", None),
+        )
+        if not _click_star_cell(driver, question_id, row_index, selected_index):
+            logging.warning("腾讯问卷第%d题（矩阵星级）第%d行点击失败。", current, row_index + 1)
+            continue
+        record_pending_distribution_choice(ctx, current, selected_index, option_count, row_index=row_index)
+        _log_qq_matrix_row_choice(
+            current,
+            row_index + 1,
+            selected_index,
+            option_texts,
+            row_probabilities,
+            raw_probabilities,
+        )
+        record_answer(current, "matrix", selected_indices=[selected_index], row_index=row_index)
+    return next_index

--- a/tencent/provider/runtime_interactions.py
+++ b/tencent/provider/runtime_interactions.py
@@ -722,6 +722,128 @@ def _click_matrix_cell(driver: BrowserDriver, provider_question_id: str, row_ind
         )
     )
 
+def _click_star_cell(driver: BrowserDriver, provider_question_id: str, row_index: int, star_index: int) -> bool:
+    """点击矩阵星级题中指定行、指定位置的星星（star_index 为 0 起始）。
+
+    腾讯问卷的星级组件基于 TDesign，使用 ``ul.t-rate`` + ``li.t-rate__star`` 结构，
+    没有 ``input[type="radio"]``，因此无法复用 _click_matrix_cell。
+    """
+    if not provider_question_id or row_index < 0 or star_index < 0:
+        return False
+    page = _page(driver)
+    return bool(
+        page.evaluate(
+            """async ({ questionId, rowIndex, starIndex }) => {
+                const section = document.querySelector(`section.question[data-question-id="${questionId}"]`);
+                if (!section || rowIndex < 0 || starIndex < 0) return false;
+
+                const wait = (ms) => new Promise((resolve) => window.setTimeout(resolve, ms));
+
+                // ── 1. 定位行容器 ───────────────────────────────────────────
+                // 优先尝试 .question-item，其次 tbody tr，最后直接找所有 .t-rate 容器
+                let row = null;
+                const questionItems = Array.from(section.querySelectorAll('.question-item'));
+                const tableRows = Array.from(section.querySelectorAll('tbody tr'));
+                const rateContainers = Array.from(section.querySelectorAll('ul.t-rate, .t-rate'));
+
+                if (questionItems.length > rowIndex) {
+                    row = questionItems[rowIndex];
+                } else if (tableRows.length > rowIndex) {
+                    row = tableRows[rowIndex];
+                } else if (rateContainers.length > rowIndex) {
+                    // 直接用第 rowIndex 个 t-rate 作为目标容器
+                    row = rateContainers[rowIndex];
+                }
+                if (!row) return false;
+
+                try { row.scrollIntoView({ block: 'center', inline: 'nearest' }); } catch (e) {}
+                await wait(120);
+
+                // ── 2. 在行内找星星列表 ────────────────────────────────────
+                // TDesign: ul.t-rate > li.t-rate__star
+                // 兼容其他可能的结构
+                const starSelectors = [
+                    'li.t-rate__star',
+                    'li[class*="rate__star"]',
+                    'ul.t-rate > li',
+                    '[class*="t-rate"] > li',
+                    '[class*="rate__list"] > li',
+                    '[class*="star-list"] > li',
+                    '[class*="star"] li',
+                ];
+                let stars = [];
+                for (const sel of starSelectors) {
+                    const found = Array.from(row.querySelectorAll(sel));
+                    if (found.length > starIndex) { stars = found; break; }
+                }
+                // 如果行容器本身就是 t-rate，直接取其 li 子元素
+                if (stars.length === 0) {
+                    const tag = String(row.tagName || '').toLowerCase();
+                    if (tag === 'ul' || row.classList.contains('t-rate')) {
+                        stars = Array.from(row.querySelectorAll('li'));
+                    }
+                }
+
+                const target = stars[starIndex];
+                if (!target) return false;
+
+                // ── 3. 判断是否已选中 ──────────────────────────────────────
+                // TDesign 选中后：前 N 个 star 会带上 t-rate__star--full / t-is-active 等
+                const isSelected = () => {
+                    if (stars.length === 0) return false;
+                    const cls0 = String(stars[0].className || '');
+                    // 若第一个 star 携带 "full" 或 "active"，说明已有评分
+                    const hasActive = stars.slice(0, starIndex + 1).some((s) => {
+                        const c = String(s.className || '');
+                        return c.includes('full') || c.includes('active') || c.includes('selected') || c.includes('filled');
+                    });
+                    return hasActive;
+                };
+
+                // ── 4. 尝试点击 ────────────────────────────────────────────
+                // 部分 TDesign 版本需要先 mouseover/mousemove 再 click 才能触发 Vue 响应
+                const doClick = async (node) => {
+                    try { node.scrollIntoView({ block: 'nearest', inline: 'nearest' }); } catch (e) {}
+                    ['mouseover', 'mouseenter', 'mousemove'].forEach((name) => {
+                        try { node.dispatchEvent(new MouseEvent(name, { bubbles: true, cancelable: true, view: window })); } catch (e) {}
+                    });
+                    await wait(60);
+                    try { node.click(); } catch (e) {}
+                    await wait(200);
+                    if (isSelected()) return true;
+                    try { node.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, view: window })); } catch (e) {}
+                    await wait(200);
+                    return isSelected();
+                };
+
+                // 先点击目标 star 内部最深的可见叶节点（通常是 SVG/icon）
+                const innerLeaf = target.querySelector('svg, use, path, i, span') || target;
+                if (await doClick(innerLeaf)) return true;
+                if (await doClick(target)) return true;
+
+                // 最后一搏：直接调用 Vue 事件（若组件挂在 __vue__/__vueParentComponent）
+                try {
+                    const vnode = target.__vueParentComponent || target.__vue__;
+                    if (vnode) {
+                        const emit = vnode.emit || (vnode.proxy && vnode.proxy.$emit);
+                        if (emit) {
+                            emit.call(vnode.proxy || vnode, 'change', starIndex + 1);
+                            await wait(200);
+                            return isSelected();
+                        }
+                    }
+                } catch (e) {}
+                return false;
+            }""",
+            {
+                "questionId": provider_question_id,
+                "rowIndex": int(row_index),
+                "starIndex": int(star_index),
+            },
+        )
+    )
+
+
 def _normalize_selected_indices(indices: Sequence[int], option_count: int) -> List[int]:
     result: List[int] = []
     seen = set()


### PR DESCRIPTION
  问题：
  - 腾讯问卷 API 返回的 star 题型（单个星级评分）未在支持列表中， 导致包含该题型的问卷在启动时报未支持题型错误，无法运行。
  - matrix_star 题型（矩阵星级）虽已在支持列表中，但运行时沿用了 针对 input[type=radio] 的点击逻辑，无法操作 TDesign t-rate 组件。

  修复（共 4 个文件）：

  parser.py
  - 将 star 加入 QQ_SUPPORTED_PROVIDER_TYPES
  - 映射 star -> type_code 5（与 nps 同类：量表/评价题）
  - _build_option_texts、_resolve_option_count 对 star 复用 nps 逻辑 （取 star_begin_num 起始、star_num 个选项）
  - is_rating 扩展为 provider_type in {nps, star}，使其在 配置向导中正确识别为评价题类型

  runtime_interactions.py
  - 新增 _click_star_cell：专门处理 TDesign ul.t-rate + li.t-rate__star 结构的矩阵星级组件；优先按 .question-item 定位行，回退至 tbody tr，最后直接定位 .t-rate 容器；点击时模拟 mouseover/mouseenter 以触发 Vue 响应式，并附带 Vue vnode emit 兜底方案

  runtime_answerers.py
  - 新增 _answer_qq_matrix_star：逻辑与 _answer_qq_matrix 相同， 但调用 _click_star_cell 代替 _click_matrix_cell

  runtime.py
  - entry_type == matrix 分支中，根据 provider_type 区分 matrix_star 与 matrix_radio，分别路由到对应 answerer

  备注：
  经过实际 DOM 检查，star 题型在页面上渲染为与 nps 相同的
  .checkbtn + input[type=radio] 结构，因此运行时无需额外处理，
  直接沿用现有 _click_choice_input 即可。
  
  测试：
  经过个人测试，填写10份数据正常。