### PR TITLE
修复有跳题的时候，识别失败

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,8 @@ __pycache__/
 /worker/.dev.vars
 /worker/.env
 /worker/.wrangler/
+
+.kiro
+docx
+tests
+scripts

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ __pycache__/
 docx
 tests
 scripts
+demo

--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,4 @@ __pycache__/
 /worker/.env
 /worker/.wrangler/
 
-.kiro
-docx
-tests
-scripts
-demo
+

--- a/wjx/provider/parser.py
+++ b/wjx/provider/parser.py
@@ -88,11 +88,33 @@ def is_paused_survey_page(html: str) -> bool:
 
 
 def build_not_open_survey_message(html: str) -> Optional[str]:
-    """构造“问卷暂未开放”提示文案。"""
+    """构造"问卷暂未开放"提示文案。"""
     text = _normalize_html_text(html)
     if not text:
         return None
+    
+    # 首先检查是否存在问卷题目容器，如果存在则说明问卷已开放
+    try:
+        from bs4 import BeautifulSoup
+        soup = BeautifulSoup(html, "html.parser")
+        # 检查是否有题目容器
+        question_container = soup.find("div", id="divQuestion")
+        if question_container:
+            # 检查是否有实际的题目（fieldset 或 topic 属性的 div）
+            has_questions = (
+                question_container.find_all("fieldset") or
+                question_container.find_all("div", attrs={"topic": True})
+            )
+            if has_questions:
+                # 有题目说明问卷已开放，不应该判定为未开放
+                return None
+    except Exception:
+        # 如果 BeautifulSoup 解析失败，继续使用文本检测
+        pass
+    
     normalized = "".join(text.split())
+    
+    # 保留所有关键词，但通过DOM检查优先避免误判
     keywords = (
         "此问卷将于",
         "请到时再进入此页面进行填写",


### PR DESCRIPTION
修改程序：wjx\provider\parser.py 的build_not_open_survey_message函数，保留原始逻辑，

修复解决了v3版本误判问卷"暂未开放"的问题。主要改进：

优先检查DOM结构：如果HTML中存在 divQuestion 容器且包含实际题目（fieldset 或带 topic 属性的 div），直接判定为已开放，避免被题目文本中的关键词误导


解析成功如下图所示：
<img width="1441" height="540" alt="image" src="https://github.com/user-attachments/assets/69d8e2f7-0013-4fd0-a8f3-1bb1e6685e17" />
